### PR TITLE
Add systemd service and an installation script

### DIFF
--- a/install-service.sh
+++ b/install-service.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "Installing network-probe service..."
+sudo cp network-probe.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable network-probe
+
+echo "Starting network-probe service..."
+sudo systemctl start network-probe
+
+echo "Done."
+

--- a/network-probe.service
+++ b/network-probe.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Network Probe
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/network-probe
+ExecStart=/usr/bin/python /home/pi/network-probe/probe.py
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Simple systemd service that automatically starts the probe on boot after network is up.

Please note that both the installation script and the service itself have hardcoded paths for specific use case with Raspberry Pi.